### PR TITLE
Drop the URLs to nexus servers

### DIFF
--- a/ncm-apel/pom.xml
+++ b/ncm-apel/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>apel NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-condorconfig/pom.xml
+++ b/ncm-condorconfig/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>condorconfig NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-dcache/pom.xml
+++ b/ncm-dcache/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>NCM component to manage dcache configuration.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-dpmlfc/pom.xml
+++ b/ncm-dpmlfc/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>NCM component to manage DPM and LFC configuration.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-frontiersquid/pom.xml
+++ b/ncm-frontiersquid/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>Used to manage FroNTier squid server</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-gacl/pom.xml
+++ b/ncm-gacl/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>gacl NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-gip2/pom.xml
+++ b/ncm-gip2/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>gip2 NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-glitestartup/pom.xml
+++ b/ncm-glitestartup/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>NCM component to configure startup of gLite services</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-globuscfg/pom.xml
+++ b/ncm-globuscfg/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>Component to manage Globus configuration</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-gold/pom.xml
+++ b/ncm-gold/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>GOLD NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-gridmapdir/pom.xml
+++ b/ncm-gridmapdir/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>gridmapdir NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-gsissh/pom.xml
+++ b/ncm-gsissh/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>gsissh NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-lbconfig/pom.xml
+++ b/ncm-lbconfig/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>lbconfig NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-lcas/pom.xml
+++ b/ncm-lcas/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>lcas NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-lcgbdii/pom.xml
+++ b/ncm-lcgbdii/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>lcgbdii NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-lcgmonjob/pom.xml
+++ b/ncm-lcgmonjob/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>lcg-mon-job-status NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-lcmaps/pom.xml
+++ b/ncm-lcmaps/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>lcmaps NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-maui/pom.xml
+++ b/ncm-maui/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>Maui NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-mkgridmap/pom.xml
+++ b/ncm-mkgridmap/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>mkgridmap NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-moab/pom.xml
+++ b/ncm-moab/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>Moab/Maui NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-myproxy/pom.xml
+++ b/ncm-myproxy/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>MyProxy NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-pbsknownhosts/pom.xml
+++ b/ncm-pbsknownhosts/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>pbsknownhosts NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-pbsserver/pom.xml
+++ b/ncm-pbsserver/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>PBS server NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-vomrs/pom.xml
+++ b/ncm-vomrs/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>VOMRS NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-vomsclient/pom.xml
+++ b/ncm-vomsclient/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>vomsclient NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-wlconfig/pom.xml
+++ b/ncm-wlconfig/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>wlconfig NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-wmsclient/pom.xml
+++ b/ncm-wmsclient/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>NCM component to configure WMS client</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-wmslb/pom.xml
+++ b/ncm-wmslb/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>NCM component to configure gLite  WMS and LB</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-xrootd/pom.xml
+++ b/ncm-xrootd/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>NCM component to manage Xrootd configuration.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-yaim/pom.xml
+++ b/ncm-yaim/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>yaim NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>

--- a/ncm-yaim_usersconf/pom.xml
+++ b/ncm-yaim_usersconf/pom.xml
@@ -9,13 +9,6 @@
   <version>13.1.2-RC3-SNAPSHOT</version>
   <name>yaim_usersconf NCM component.</name>
 
-  <repositories>
-    <repository>
-      <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/nexus/content/repositories/releases/</url>
-    </repository>
-  </repositories>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>


### PR DESCRIPTION
lapp-repo01.in2p3.fr nexus server no more response. We must use stratuslab-srv01.lal.in2p3.fr instead, which is provided already by the parent POM.
