### PR TITLE
ncm-wmslb: reestablish ApacheLogLevel option used by the template library

### DIFF
--- a/ncm-wmslb/src/main/pan/components/wmslb/schema.pan
+++ b/ncm-wmslb/src/main/pan/components/wmslb/schema.pan
@@ -294,7 +294,7 @@ type ${project.artifactId}_component_service_wmproxy_loadmonitor_opts = {
 #};
 
 type ${project.artifactId}_component_service_wmproxy_opts = {
-#  'ApacheLogLevel'               ? string with match(SELF,'emerg|alert|crit|error|warn|notice|info|debug')
+  'ApacheLogLevel'               ? string with match(SELF,'emerg|alert|crit|error|warn|notice|info|debug')
   'ArgusAuthz'                   ? boolean
   'ArgusPepEndpoints'            ? string{}
   'AsyncJobStart'                ? boolean


### PR DESCRIPTION
Required for 14.5 to fix https://github.com/quattor/template-library-core/issues/43 (showstopper).
