### PR TITLE
ncm-gip2: += create static LDIF files using the output of an external command

### DIFF
--- a/ncm-gip2/src/main/pan/components/gip2/schema.pan
+++ b/ncm-gip2/src/main/pan/components/gip2/schema.pan
@@ -18,6 +18,11 @@ type structure_gip2_ldif = {
     'staticInfoArgs'        ? string
 };
 
+type structure_gip2_standardOutput = {
+    'command'               : string = '/bin/echo'
+    'arguments'             : string = '-n'
+};
+
 type ${project.artifactId}_component = {
     include structure_component
     'user'                  : string
@@ -38,6 +43,7 @@ type ${project.artifactId}_component = {
     'provider'              ? string{}
     'scripts'               ? string{}
     'stubs'                 ? structure_gip2_attribute{}{}{}
+    'standardOutput'        ? structure_gip2_standardOutput{}
     'external'              ? string[]
 };
 

--- a/ncm-gip2/src/main/perl/gip2.pod
+++ b/ncm-gip2/src/main/perl/gip2.pod
@@ -100,6 +100,12 @@ If stubs are defined, BDII will be restarted if running on the current node.
 
 Default : none.
 
+=head2 /software/components/gip2/standardOutput : nlist (optional)
+
+Named list of files to be produced from the standard output of an executable. The key is the target file name, each value is a structure with command and arguments attributes.
+
+Default : none.
+
 =head2 /software/components/gip2/external : list of strings (optional)
 
 List of files/scripts that will be trusted as if managed by the component.


### PR DESCRIPTION
This change should allow solving issue quattor/template-library-grid#45.
