### PR TITLE
ncm-vomsclient: end .lsc files with new-line character

### DIFF
--- a/ncm-vomsclient/src/main/perl/vomsclient.pm
+++ b/ncm-vomsclient/src/main/perl/vomsclient.pm
@@ -134,7 +134,7 @@ sub lscfile_configuration($$@) {
         my $fname;
         my $contents;
         $fname = "$vodir/$host.lsc";
-        $fileinfo{$fname} = $dn . "\n" . $issuer;
+        $fileinfo{$fname} = $dn . "\n" . $issuer . "\n";
 
         $contents =
             '"' . $name . '" ' . '"' . $host . '" ' . '"' . $port . '" ' . '"'


### PR DESCRIPTION
Fixes #34
