### PR TITLE
glitestartup: fix EMI support

### DIFF
--- a/ncm-glitestartup/src/main/templates/gLite.template
+++ b/ncm-glitestartup/src/main/templates/gLite.template
@@ -1,27 +1,17 @@
 #!/bin/bash
 ###############################################################################
-#
-#       Copyright (c) Members of the EGEE Collaboration. 2004
-#       See http://eu-egee.org/partners/ for details on the copyright holders
-#       For license conditions see the license file or http://eu-egee.org/license.html
-#
-#   Startup script for POST stage setup
+# IMPORTANT:
+# - This script is managed by ncm-glitestartup configuration module: DO NOT EDIT
+# - The template is written in ncm-template syntax: be sure to escape \< and \>
 #
 #   chkconfig: 345 96 96
-#
-#   description:  gLite startup script
+#   description:  gLite startup script used by WMS and LB services
 #
 #   processname: gLite
 #
+#   Based on script once provided by EGEE.
 #   Author(s): Marian ZUREK \<Marian.ZUREK@cern.ch\> 
 #        Nuno SILVA \<Nuno.Orestes.Vaz.da.Silva@cern.ch\>
-#
-#   Version: V1.1 for Yaim-core-4
-#
-#   Date: 07/08/2007
-#
-# IMPORTANT:
-# The template is written in ncm-template syntax: be sure to escape \< and \>
 #
 ###############################################################################
 
@@ -29,12 +19,7 @@
 . <restartEnv/<$script>>;
 <ENDFOR>
 
-if [ "x$GLITE_LOCATION" = "x/usr" ]
-then
- GLITE_LOCATION="/"
-fi
- 
-GLITE_STARTUP_SCRIPT_DIR=${GLITE_LOCATION}/etc/init.d/
+GLITE_STARTUP_SCRIPT_DIR=${EMI_LOCATION}/etc/init.d/
 
 if [ ! -d ${GLITE_STARTUP_SCRIPT_DIR} ]
 then
@@ -42,7 +27,7 @@ then
         exit 1
 fi
 
-GLITE_STARTUP_FILE=${GLITE_LOCATION}/etc/gLiteservices
+GLITE_STARTUP_FILE=${EMI_LOCATION}/etc/gLiteservices
 
 if [ ! -r ${GLITE_STARTUP_FILE} ]
 then


### PR DESCRIPTION
- Remove redefinition of GLITE_LOCATION to a value unexpected by other components
- Use EMI_LOCATION instead, if defined (else defaults to an empty string)

A rathere annoying bug uncovered when fixing https://github.com/quattor/template-library-grid/issues/79.
