### PR TITLE
ncm-gsissh: make compatible with recent version of gsissh

### DIFF
--- a/ncm-gsissh/src/main/perl/gsissh.pm
+++ b/ncm-gsissh/src/main/perl/gsissh.pm
@@ -92,7 +92,7 @@ sub Configure($$@) {
 		$self->error("error running $script");
 		return 1;
 	    }
-	} else {
+	} elsif (-f $script) {
 	    $self->error("$script isn't executable");
 	    return 1;
 	}
@@ -118,7 +118,7 @@ sub Configure($$@) {
 	    }
 	    close INITD;
 	} else {
-	    $self->error("$globus_location/sbin/SXXsshd doesn't exist");
+	    $self->warn("$globus_location/sbin/SXXsshd doesn't exist");
 	    return 1;
 	}
 


### PR DESCRIPTION
- Execute the setup script only if it exists
- Do not hack the startup script if it doesn't exist

Fixes https://github.com/quattor/template-library-grid/issues/83

There is no attempt to improve this component that should probably be deprecated in a future release. Just an attempt to make it a not too bad citizen (not returning errors for things that don't have sense anymore) with a very minimalistic modification.
