### PR TITLE
add authorized_users field

### DIFF
--- a/ncm-pbsserver/src/main/pan/components/pbsserver/schema.pan
+++ b/ncm-pbsserver/src/main/pan/components/pbsserver/schema.pan
@@ -123,6 +123,8 @@ type pbs_server_attlist = {
     'checkpoint_dir'    ? string
 
     'moab_array_compatible' ? boolean
+    
+    'authorized_users'	  ? string
 };
 
 type pbs_server = {


### PR DESCRIPTION
This field is mandatory when using pbs_server in conjonction with MUNGE
The format will be like : user1@hosta (wildcard allowed for the user part)
