### PR TITLE
ncm-gip2: fix missing retrieval of parameters in write_encoded()

### DIFF
--- a/ncm-gip2/src/main/perl/gip2.pm
+++ b/ncm-gip2/src/main/perl/gip2.pm
@@ -23,7 +23,7 @@ use File::Basename;
 local(*DTA);
 
 sub write_encoded {
-    my ($self, $file, $perm, $contents);
+    my ($self, $file, $perm, $contents) = @_;
     my $fh = CAF::FileWriter->new($file, mode => $perm, log => $self);
     print $fh encode_utf8($contents);
     return $fh->close();


### PR DESCRIPTION
Fixes #50.
