### PR TITLE
ncm-xrootd: bump build tools to 1.40 for EL7

### DIFF
--- a/ncm-xrootd/pom.xml
+++ b/ncm-xrootd/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.38</version>
+    <version>1.40</version>
   </parent>
 
   <licenses>


### PR DESCRIPTION
This is required to pass the unittests on EL7