### PR TITLE
ncm-pbsserver: power_state is also a unmodifiable attribute

### DIFF
--- a/ncm-pbsserver/src/main/perl/pbsserver.pm
+++ b/ncm-pbsserver/src/main/perl/pbsserver.pm
@@ -365,6 +365,7 @@ sub Configure
                         if (!defined($definednatt{$_}) &&
                                 ($_ ne "ntype") &&
                                 ($_ ne "state") &&
+                                ($_ ne "power_state") &&
                                 ($_ ne "properties") &&
                                 ($_ ne "status")) {
                             $self->runCommand($qmgr, "unset node $node $_");


### PR DESCRIPTION
The component parses pbsnodes output, and only a few of the attribute can actually be modified.
`power_state` is among those which cannot be modified.