### PR TITLE
Fix missing template files

### DIFF
--- a/ncm-condorconfig/pom.xml
+++ b/ncm-condorconfig/pom.xml
@@ -47,5 +47,66 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+
+          <executions>
+
+            <execution>
+              <id>filter-template-sources</id>
+              <phase>process-sources</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <configuration>
+                <encoding>UTF-8</encoding>
+                <delimiters>
+                  <delimiter>${*}</delimiter>
+                </delimiters>
+                <outputDirectory>${project.build.directory}/templates</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>src/main/templates</directory>
+                    <filtering>true</filtering>
+                    <includes>
+                      <include>*</include>
+                    </includes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+
+          <configuration>
+            <mappings combine.children="append">
+              <mapping>
+                <directory>/usr/lib/ncm/config/${project.artifactId}</directory>
+                <filemode>644</filemode>
+                <username>root</username>
+                <groupname>root</groupname>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>target/templates</location>
+                  </source>
+                </sources>
+              </mapping>
+            </mappings>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-glitestartup/pom.xml
+++ b/ncm-glitestartup/pom.xml
@@ -47,5 +47,66 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+
+          <executions>
+
+            <execution>
+              <id>filter-template-sources</id>
+              <phase>process-sources</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <configuration>
+                <encoding>UTF-8</encoding>
+                <delimiters>
+                  <delimiter>${*}</delimiter>
+                </delimiters>
+                <outputDirectory>${project.build.directory}/templates</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>src/main/templates</directory>
+                    <filtering>true</filtering>
+                    <includes>
+                      <include>*</include>
+                    </includes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+
+          <configuration>
+            <mappings combine.children="append">
+              <mapping>
+                <directory>/usr/lib/ncm/config/${project.artifactId}</directory>
+                <filemode>644</filemode>
+                <username>root</username>
+                <groupname>root</groupname>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>target/templates</location>
+                  </source>
+                </sources>
+              </mapping>
+            </mappings>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-lcgbdii/pom.xml
+++ b/ncm-lcgbdii/pom.xml
@@ -47,5 +47,66 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+
+          <executions>
+
+            <execution>
+              <id>filter-template-sources</id>
+              <phase>process-sources</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <configuration>
+                <encoding>UTF-8</encoding>
+                <delimiters>
+                  <delimiter>${*}</delimiter>
+                </delimiters>
+                <outputDirectory>${project.build.directory}/templates</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>src/main/templates</directory>
+                    <filtering>true</filtering>
+                    <includes>
+                      <include>*</include>
+                    </includes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+
+          <configuration>
+            <mappings combine.children="append">
+              <mapping>
+                <directory>/usr/lib/ncm/config/${project.artifactId}</directory>
+                <filemode>644</filemode>
+                <username>root</username>
+                <groupname>root</groupname>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>target/templates</location>
+                  </source>
+                </sources>
+              </mapping>
+            </mappings>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-vomrs/pom.xml
+++ b/ncm-vomrs/pom.xml
@@ -47,5 +47,66 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+
+          <executions>
+
+            <execution>
+              <id>filter-template-sources</id>
+              <phase>process-sources</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <configuration>
+                <encoding>UTF-8</encoding>
+                <delimiters>
+                  <delimiter>${*}</delimiter>
+                </delimiters>
+                <outputDirectory>${project.build.directory}/templates</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>src/main/templates</directory>
+                    <filtering>true</filtering>
+                    <includes>
+                      <include>*</include>
+                    </includes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+
+          <configuration>
+            <mappings combine.children="append">
+              <mapping>
+                <directory>/usr/lib/ncm/config/${project.artifactId}</directory>
+                <filemode>644</filemode>
+                <username>root</username>
+                <groupname>root</groupname>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>target/templates</location>
+                  </source>
+                </sources>
+              </mapping>
+            </mappings>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-wlconfig/pom.xml
+++ b/ncm-wlconfig/pom.xml
@@ -47,5 +47,66 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+
+          <executions>
+
+            <execution>
+              <id>filter-template-sources</id>
+              <phase>process-sources</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <configuration>
+                <encoding>UTF-8</encoding>
+                <delimiters>
+                  <delimiter>${*}</delimiter>
+                </delimiters>
+                <outputDirectory>${project.build.directory}/templates</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>src/main/templates</directory>
+                    <filtering>true</filtering>
+                    <includes>
+                      <include>*</include>
+                    </includes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+
+          <configuration>
+            <mappings combine.children="append">
+              <mapping>
+                <directory>/usr/lib/ncm/config/${project.artifactId}</directory>
+                <filemode>644</filemode>
+                <username>root</username>
+                <groupname>root</groupname>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>target/templates</location>
+                  </source>
+                </sources>
+              </mapping>
+            </mappings>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-wmsclient/pom.xml
+++ b/ncm-wmsclient/pom.xml
@@ -47,5 +47,66 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+
+          <executions>
+
+            <execution>
+              <id>filter-template-sources</id>
+              <phase>process-sources</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <configuration>
+                <encoding>UTF-8</encoding>
+                <delimiters>
+                  <delimiter>${*}</delimiter>
+                </delimiters>
+                <outputDirectory>${project.build.directory}/templates</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>src/main/templates</directory>
+                    <filtering>true</filtering>
+                    <includes>
+                      <include>*</include>
+                    </includes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+
+          <configuration>
+            <mappings combine.children="append">
+              <mapping>
+                <directory>/usr/lib/ncm/config/${project.artifactId}</directory>
+                <filemode>644</filemode>
+                <username>root</username>
+                <groupname>root</groupname>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>target/templates</location>
+                  </source>
+                </sources>
+              </mapping>
+            </mappings>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-wmslb/pom.xml
+++ b/ncm-wmslb/pom.xml
@@ -40,5 +40,66 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+
+          <executions>
+
+            <execution>
+              <id>filter-template-sources</id>
+              <phase>process-sources</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <configuration>
+                <encoding>UTF-8</encoding>
+                <delimiters>
+                  <delimiter>${*}</delimiter>
+                </delimiters>
+                <outputDirectory>${project.build.directory}/templates</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>src/main/templates</directory>
+                    <filtering>true</filtering>
+                    <includes>
+                      <include>*</include>
+                    </includes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+
+          <configuration>
+            <mappings combine.children="append">
+              <mapping>
+                <directory>/usr/lib/ncm/config/${project.artifactId}</directory>
+                <filemode>644</filemode>
+                <username>root</username>
+                <groupname>root</groupname>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>target/templates</location>
+                  </source>
+                </sources>
+              </mapping>
+            </mappings>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-yaim/pom.xml
+++ b/ncm-yaim/pom.xml
@@ -47,5 +47,66 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+
+          <executions>
+
+            <execution>
+              <id>filter-template-sources</id>
+              <phase>process-sources</phase>
+              <goals>
+                <goal>copy-resources</goal>
+              </goals>
+              <configuration>
+                <encoding>UTF-8</encoding>
+                <delimiters>
+                  <delimiter>${*}</delimiter>
+                </delimiters>
+                <outputDirectory>${project.build.directory}/templates</outputDirectory>
+                <resources>
+                  <resource>
+                    <directory>src/main/templates</directory>
+                    <filtering>true</filtering>
+                    <includes>
+                      <include>*</include>
+                    </includes>
+                  </resource>
+                </resources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+
+          <configuration>
+            <mappings combine.children="append">
+              <mapping>
+                <directory>/usr/lib/ncm/config/${project.artifactId}</directory>
+                <filemode>644</filemode>
+                <username>root</username>
+                <groupname>root</groupname>
+                <directoryIncluded>false</directoryIncluded>
+                <sources>
+                  <source>
+                    <location>target/templates</location>
+                  </source>
+                </sources>
+              </mapping>
+            </mappings>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>


### PR DESCRIPTION
- Affected configuration modules: condorconfig, glitestartup, lcgbdii, vomrs, wlconfig, wmsclient, wmslb, yaim
- Instructions inadvertently removed from pom files at commit 84367a0a8c132344c4f0494519df55a9bcd09f43

Fixes #68