### PR TITLE
ncm-yaim_usersconf: Include correct component base structure

### DIFF
--- a/ncm-yaim_usersconf/src/main/pan/components/yaim_usersconf/schema.pan
+++ b/ncm-yaim_usersconf/src/main/pan/components/yaim_usersconf/schema.pan
@@ -36,7 +36,7 @@ type structure_yaim_usersconf_vo = {
 };
 
 type ${project.artifactId}_component = {
-    include component_type
+    include structure_component
     "users_conf_file"  ? string # "location of users.conf file"
     "groups_conf_file" ? string # "location of groups.conf file"
     "vo"               ? structure_yaim_usersconf_vo{}


### PR DESCRIPTION
`component_type` has not existed for a very long time, so this component has
apparently been broken for years without anyone noticing.

Needed to get unit-tests passing on `template-library-core`.