### PR TITLE
ncm-xrootd: Drop support for logKeep as a long

### DIFF
--- a/ncm-xrootd/src/main/pan/components/xrootd/schema.pan
+++ b/ncm-xrootd/src/main/pan/components/xrootd/schema.pan
@@ -177,14 +177,10 @@ type ${project.artifactId}_component_fed_options = {
 };
 
 function is_${project.artifactId}_logKeep = {
-  if (is_long(ARGV[0])) {
-    deprecated(0, "Expressing logKeep as a long is deprecated, it should be expressed as a string.");
-    return(true);
-  };
-  return(match(ARGV[0], '^([0-9]+[k|m|g]?|fifo|hup|rtmin(\+[12])?|ttou|winch|xfsz)$'));
+  match(ARGV[0], '^([0-9]+[k|m|g]?|fifo|hup|rtmin(\+[12])?|ttou|winch|xfsz)$');
 };
 
-type ${project.artifactId}_logKeep = property with is_${project.artifactId}_logKeep(SELF);
+type ${project.artifactId}_logKeep = string with is_${project.artifactId}_logKeep(SELF);
 
 type ${project.artifactId}_component_instances = {
   "configFile" : string


### PR DESCRIPTION
This finishes the deprecation path started in #71.

Resolves #79.