### PR TITLE
Adapt unittests to new buildtools

### DIFF
--- a/ncm-condorconfig/src/test/perl/00-load.t
+++ b/ncm-condorconfig/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::condorconfig");

--- a/ncm-dcache/src/test/perl/00-load.t
+++ b/ncm-dcache/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::dcache");

--- a/ncm-dpmlfc/src/test/perl/00-load.t
+++ b/ncm-dpmlfc/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::dpmlfc");

--- a/ncm-gacl/src/test/perl/00-load.t
+++ b/ncm-gacl/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::gacl");

--- a/ncm-gip2/src/test/perl/00-load.t
+++ b/ncm-gip2/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::gip2");

--- a/ncm-glitestartup/src/test/perl/00-load.t
+++ b/ncm-glitestartup/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::glitestartup");

--- a/ncm-globuscfg/src/test/perl/00-load.t
+++ b/ncm-globuscfg/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::globuscfg");

--- a/ncm-gold/src/test/perl/00-load.t
+++ b/ncm-gold/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::gold");

--- a/ncm-gridmapdir/src/test/perl/00-load.t
+++ b/ncm-gridmapdir/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::gridmapdir");

--- a/ncm-gsissh/src/test/perl/00-load.t
+++ b/ncm-gsissh/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::gsissh");

--- a/ncm-lbconfig/src/test/perl/00-load.t
+++ b/ncm-lbconfig/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::lbconfig");

--- a/ncm-lcas/src/test/perl/00-load.t
+++ b/ncm-lcas/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::lcas");

--- a/ncm-lcgbdii/src/test/perl/00-load.t
+++ b/ncm-lcgbdii/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::lcgbdii");

--- a/ncm-lcgmonjob/src/test/perl/00-load.t
+++ b/ncm-lcgmonjob/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::lcgmonjob");

--- a/ncm-lcmaps/src/test/perl/00-load.t
+++ b/ncm-lcmaps/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::lcmaps");

--- a/ncm-maui/src/test/perl/00-load.t
+++ b/ncm-maui/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::maui");

--- a/ncm-mkgridmap/src/test/perl/00-load.t
+++ b/ncm-mkgridmap/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::mkgridmap");

--- a/ncm-moab/src/test/perl/00-load.t
+++ b/ncm-moab/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::moab");

--- a/ncm-myproxy/src/test/perl/00-load.t
+++ b/ncm-myproxy/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::myproxy");

--- a/ncm-pbsclient/src/test/perl/00-load.t
+++ b/ncm-pbsclient/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::pbsclient");

--- a/ncm-pbsknownhosts/src/test/perl/00-load.t
+++ b/ncm-pbsknownhosts/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::pbsknownhosts");

--- a/ncm-pbsserver/src/test/perl/00-load.t
+++ b/ncm-pbsserver/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::pbsserver");

--- a/ncm-vomsclient/src/test/perl/00-load.t
+++ b/ncm-vomsclient/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::vomsclient");

--- a/ncm-wlconfig/src/test/perl/00-load.t
+++ b/ncm-wlconfig/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::wlconfig");

--- a/ncm-wmsclient/src/test/perl/00-load.t
+++ b/ncm-wmsclient/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::wmsclient");

--- a/ncm-wmslb/src/test/perl/00-load.t
+++ b/ncm-wmslb/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::wmslb");

--- a/ncm-xrootd/src/test/perl/00-load.t
+++ b/ncm-xrootd/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::xrootd");

--- a/ncm-yaim/src/test/perl/00-load.t
+++ b/ncm-yaim/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::yaim");

--- a/ncm-yaim_usersconf/src/test/perl/00-load.t
+++ b/ncm-yaim_usersconf/src/test/perl/00-load.t
@@ -1,4 +1,3 @@
-# -*- mode: cperl -*-
 # ${license-info}
 # ${author-info}
 # ${build-info}
@@ -9,13 +8,11 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything to SF without
-having run, at least, this test.
-
 =cut
 
 use strict;
 use warnings;
 use Test::More tests => 1;
+use Test::Quattor;
 
 use_ok("NCM::Component::yaim_usersconf");


### PR DESCRIPTION
New testtools will not provide NCM:: via prove include path, but it will be handled via Test::Quattor
(this requires no new buildtools)