### PR TITLE
ncm-pbsserver: cleanup handling of special/readonly node attributes

### DIFF
--- a/ncm-pbsserver/src/main/perl/pbsserver.pm
+++ b/ncm-pbsserver/src/main/perl/pbsserver.pm
@@ -51,7 +51,7 @@ sub Configure
     }
     mkpath($pbsroot, 0, 0755) unless (-e $pbsroot);
     if (! -d $pbsroot) {
-        $self->Fail("Can't create directory: $pbsroot");
+        $self->error("Can't create directory: $pbsroot");
         return 1;
     }
 

--- a/ncm-pbsserver/src/main/perl/pbsserver.pm
+++ b/ncm-pbsserver/src/main/perl/pbsserver.pm
@@ -1,15 +1,6 @@
-# ${license-info}
-# ${developer-info}
-# ${author-info}
-# ${build-info}
-#
+#${PMpre} NCM::Component::pbsserver${PMpost}
 
-package NCM::Component::pbsserver;
-
-use strict;
-use warnings;
-
-use parent qw(NCM::Component);
+use parent qw(NCM::Component CAF::Path);
 
 our $EC = LC::Exception::Context->new->will_store_all;
 our $NoActionSupported = 1;
@@ -18,10 +9,10 @@ use CAF::Process;
 use CAF::Service;
 use CAF::FileWriter;
 
-use File::Path qw(mkpath);
+use Readonly;
 
 # Filter out any matching pbsnodes attributes from further processing
-use constant FILTER_PBSNODES_PATTERNS => qw(
+Readonly::Array my @FILTER_PBSNODES_PATTERNS => qw(
     state ntype power_state
     status jobs note
     mom_(manager|service)_port
@@ -38,34 +29,32 @@ sub Configure
     my ($self, $config) = @_;
 
     # Define paths for convenience and retrieve configuration
-    my $base = "/software/components/pbsserver";
-    my $tree = $config->getElement($base)->getTree();
+    my $tree = $config->getTree($self->prefix());
 
-    # set to true if service was (re)started
-    my $started = 0;
 
     # Retrieve location for pbs working directory and ensure it exists.
-    my $pbsroot = "/var/torque";
-    if ( $tree->{pbsroot} ) {
-        $pbsroot = $tree->{pbsroot};
-    }
-    mkpath($pbsroot, 0, 0755) unless (-e $pbsroot);
-    if (! -d $pbsroot) {
-        $self->error("Can't create directory: $pbsroot");
+    my $pbsroot = $tree->{pbsroot} || "/var/torque";
+
+    if (! $self->directory($pbsroot)) {
+        $self->error("Can't create directory $pbsroot: $self->{fail}");
         return 1;
     }
 
     my $srv = CAF::Service->new(['pbs_server'], log => $self);
+    # set to true if service was (re)started
+    my $started = 0;
 
     # Determine the location of the pbs commands.
-    my $binpath = "/usr/bin";
-    if ( $tree->{binpath} ) {
-        $binpath = $tree->{binpath};
-    };
+    my $binpath = $tree->{binpath} || "/usr/bin";
 
     my $serverdb = "$pbsroot/server_priv/serverdb";
-    if (! -f $serverdb) {
+    if (! $self->file_exists($serverdb)) {
         $self->info("serverdb $serverdb is missing.");
+
+        if (! $srv->stop()) {
+            $self->warn('pbs_server stop failed before create (normal in not started yet): '. $?);
+        };
+
         # force is ok, because the serverdb is missing
         return 1 if (! defined($self->force_create($binpath, $pbsroot)));
 
@@ -88,6 +77,7 @@ sub Configure
                                           log => $self,
                                           );
         print $fh_env $contents;
+
         if($fh_env->close()) {
             $self->verbose("$fname updated. Restarting pbs_server...");
             $started = 1;
@@ -125,30 +115,33 @@ sub Configure
     # this is far from true. if something else manages torque.cfg, set ignoretorquecfg to true
     } else {
         $self->info("Removing submission filter...");
-        unlink "$pbsroot/submit_filter" if (-e "$pbsroot/submit_filter");
+        $self->cleanup("$pbsroot/submit_filter");
 
-        my $removetorquecfg = -e "$pbsroot/torque.cfg";
+        my $removetorquecfg = $self->file_exists("$pbsroot/torque.cfg");
         if ($tree->{ignoretorquecfg}) {
             $removetorquecfg = 0;
             $self->info("Ignoring torque.cfg file.");
         };
-        unlink "$pbsroot/torque.cfg" if ($removetorquecfg);
+        $self->cleanup("$pbsroot/torque.cfg") if ($removetorquecfg);
     }
 
 
-    $qmgr = "$binpath/qmgr";
+    $self->set_qmgr("$binpath/qmgr");
     my $pbsnodes = "$binpath/pbsnodes";
-    if (! (-x $qmgr)) {
-        $self->error("$qmgr isn't executable");
-        return 1;
+
+    foreach my $bin ($qmgr, $pbsnodes) {
+        if (! $self->file_exists($bin)) {
+            $self->error("$bin does not exist");
+            return 1;
+        }
     }
-    if (! (-x $pbsnodes)) {
-        $self->error("$pbsnodes isn't executable");
-        return 1;
-    }
+
 
     my $existing = $self->get_current_config($started);
-    return 1 if (! defined($existing));
+    if (! defined($existing)) {
+        $self->error("No existing config found");
+        return 1;
+    }
 
 
     # server configuration
@@ -259,22 +252,26 @@ sub Configure
     # avoids having to rerun the command.
     my %existingnodes;
     my $lastnode = '';
-    my $filterpattern = '^(' . join('|', FILTER_PBSNODES_PATTERNS) . ')$';
-    my $filterregexp = qr{$filterpattern};
-    $self->verbose("pbsnodes attributes filter regexp $filterregexp");
-    if (-e "$pbsroot/server_priv/nodes" && -s "$pbsroot/server_priv/nodes") {
+
+    my $nodesfn = "$pbsroot/server_priv/nodes";
+    if ($self->file_exists($nodesfn)) {
         my $output = CAF::Process->new([$pbsnodes, '-a'], log => $self, keeps_state => 1)->output();
         if ($?) {
             $self->error("error running $pbsnodes");
             return 1;
         }
-        foreach (split(/\n/, $output)) {
-            chomp;
-            if (m/(^[\w\d\.-]+)\s*$/) {
+
+        my $filterpattern = '^(' . join('|', @FILTER_PBSNODES_PATTERNS) . ')$';
+        my $filterregexp = qr{$filterpattern};
+        $self->verbose("pbsnodes attributes filter regexp $filterregexp");
+
+        foreach my $line (split(/\n/, $output)) {
+            chomp($line);
+            if ($line =~ m/(^[\w\d\.-]+)\s*$/) {
                 # Start of a section with node name.
                 $lastnode = $1;
                 $existingnodes{$lastnode} = {};
-            } elsif (m/^\s*(\w+)\s*=\s*(.*)/) {
+            } elsif ($line =~ m/^\s*(\w+)\s*=\s*(.*)/) {
                 # This is an attribute.  Attach it to last node.
                 my $name = $1;
                 my $value = $2;
@@ -284,7 +281,10 @@ sub Configure
                 }
             }
         }
+    } else {
+        $self->verbose("nodes file $nodesfn not found, not checking any exiting nodes");
     }
+
 
     # node configuration
     # $nodebase--+
@@ -371,6 +371,18 @@ sub Configure
 }
 
 
+# Set qmgr module variable to qmgr_bin (if defined)
+# Returns value of qmgr
+sub set_qmgr
+{
+    my ($self, $qmgr_bin) = @_;
+
+    $qmgr = $qmgr_bin if defined($qmgr_bin);
+
+    return $qmgr;
+}
+
+
 # For hashref cfg, return if component is allowed to make changes
 # (it checks if the manualconfig attribute is set and false)
 sub allowed
@@ -427,7 +439,7 @@ sub qmgr
     if ($?) {
 	   $self->error("Failed to run $qmgr $cmd: $out (", $? >> 8, ")");
     } else {
-	   $self->debug(2, "OK: $cmd");
+	   $self->debug(2, "qmgr $cmd successful");
     }
     return $out;
 }
@@ -459,17 +471,17 @@ sub get_current_config
     }
 
     my $existing;
-    foreach (split('\n', $current_config)) {
-        chomp;
-        if (m/set server ([\w\.]+)/) {
+    foreach my $line (split('\n', $current_config)) {
+        chomp $line;
+        if ($line =~ m/set server ([\w\.]+)/) {
             # Mark the server attribute as set.
             $existing->{satt}->{$1} = 1;
 
-        } elsif (m/create queue ([\w\.\-]+)/) {
+        } elsif ($line =~ m/create queue ([\w\.\-]+)/) {
             # Create a hash for the queue.
             $existing->{queues}->{$1} = {};
 
-        } elsif (m/set queue ([\w\.\-]+)\s+([\w\.]+)/) {
+        } elsif ($line =~ m/set queue ([\w\.\-]+)\s+([\w\.]+)/) {
             # Mark the attribute as set for the given queue.
             my $queue = $1;
             my $name = $2;

--- a/ncm-pbsserver/src/test/perl/simple.t
+++ b/ncm-pbsserver/src/test/perl/simple.t
@@ -1,0 +1,174 @@
+use strict;
+use warnings;
+
+BEGIN {
+    *CORE::GLOBAL::sleep = sub {};
+}
+
+use Test::More;
+use CAF::Object;
+use Test::Quattor qw(simple);
+use NCM::Component::pbsserver;
+
+
+use Readonly;
+
+# Very minimal server config
+Readonly my $PRINT_SERVER => <<'EOF';
+
+create queue q24h
+set queue q24h queue_type = Execution
+set queue q24h Priority = 60
+
+create queue default
+set queue default queue_type = Route
+set queue default route_destinations = short
+set queue default route_destinations += long
+set queue default enabled = True
+set queue default started = True
+
+
+set server scheduling = True
+set server acl_host_enable = False
+set server acl_hosts = localhost
+set server acl_hosts += some.server
+set server to = remove
+
+EOF
+
+Readonly my $PBSNODES => <<'EOF';
+node0.example.com
+    state = job-exclusive
+    power_state = Running
+    np = 20
+    properties = prop1,prop2
+    ntype = cluster
+    jobs = 10-19/123.master.example.comf,0-9/456.master.example.com
+    status = rectime=some,garbage
+    mom_service_port = 15002
+    mom_manager_port = 15003
+    total_sockets = 2
+    total_numa_nodes = 4
+    total_cores = 20
+    total_threads = 20
+    dedicated_sockets = 0
+    dedicated_numa_nodes = 0
+    dedicated_cores = 0
+    dedicated_threads = 20
+
+node1.example.com
+    state = job-exclusive
+    power_state = Running
+    np = 20
+    properties = prop1,prop2
+    ntype = cluster
+    jobs = 10-19/123.master.example.comf,0-9/456.master.example.com
+    status = rectime=some,garbage
+    mom_service_port = 15002
+    mom_manager_port = 15003
+    total_sockets = 2
+    total_numa_nodes = 4
+    total_cores = 20
+    total_threads = 20
+    dedicated_sockets = 0
+    dedicated_numa_nodes = 0
+    dedicated_cores = 0
+    dedicated_threads = 20
+EOF
+
+$CAF::Object::NoAction = 1;
+
+set_caf_file_close_diff(1);
+
+my $cfg = get_config_for_profile('simple');
+my $cmp = NCM::Component::pbsserver->new('simple');
+
+set_file_contents("/var/spool/maui/maui.cfg", "something");
+
+# Set expected binaries
+set_file_contents("/usr/bin/qmgr", "qmgr");
+set_file_contents("/usr/bin/pbsnodes", "pbsnodes");
+
+# Only has to exist, content is not actually used
+set_file_contents("/var/spool/pbs/server_priv/nodes", "all nodes");
+
+set_desired_output('/usr/bin/qmgr -c print server', $PRINT_SERVER);
+set_desired_output('/usr/bin/pbsnodes -a', $PBSNODES);
+
+command_history_reset();
+$cmp->set_qmgr('/usr/bin/qmgr');
+diag explain $cmp->get_current_config();
+is_deeply($cmp->get_current_config(), {
+    satt => {
+        scheduling => 1,
+        acl_host_enable => 1,
+        acl_hosts => 1,
+        to => 1,
+    },
+    queues => {
+        default => {
+            enabled => 1,
+            queue_type => 1,
+            route_destinations => 1,
+            started => 1,
+        },
+        q24h => {
+            Priority => 1,
+            queue_type => 1,
+        },
+    },
+}, "Current config from PRINT_SERVER");
+ok(command_history_ok(['qmgr -c print server']), "expected commands for get_current_config");
+
+command_history_reset();
+is($cmp->Configure($cfg), 1, "Component runs correctly with a test profile");
+
+my $fh = get_file("/var/spool/pbs/server_name");
+is("$fh", "master.example.com\n", "server_name file created");
+
+ok(command_history_ok([
+    # missing serverdb
+    'service pbs_server stop',
+    '/usr/sbin/pbs_server -d /var/spool/pbs -t create -f',
+    'service pbs_server start',
+    # current config
+    'qmgr -c print server',
+    # set/unset server attributes
+    'qmgr -c set server down_on_error = 1',
+    'qmgr -c set server scheduling = 1',
+    'qmgr -c set server server_name = master.example.com',
+    'qmgr -c unset server acl_host_enable',
+    'qmgr -c unset server to',
+    # restart due to changed server_name
+    'service pbs_server restart',
+    # queues
+    'qmgr -c print server',
+    'qmgr -c set queue default queue_type = Route',
+    'qmgr -c set queue default route_destinations = "short,long"',
+    'qmgr -c set queue default enabled = 1',
+    'qmgr -c set queue default started = 1',
+    'qmgr -c create queue q72h',
+    'qmgr -c set queue q72h Priority = 60',
+    'qmgr -c set queue q72h acl_group_enable = 1',
+    'qmgr -c set queue q72h acl_group_sloppy = 1',
+    'qmgr -c set queue q72h acl_groups = "gpilot,wheel"',
+    'qmgr -c set queue q72h queue_type = Execution',
+    'qmgr -c set queue q72h enabled = 1',
+    'qmgr -c delete queue q24h',
+    # node state
+    'pbsnodes -a',
+    'qmgr -c set node node1.example.com np = 20',
+    'qmgr -c set node node1.example.com properties \+= prop3',
+    "qmgr -c set node node1.example.com properties -= 'prop1'",
+    'qmgr -c create node node2.example.com',
+    'qmgr -c set node node2.example.com np = 22',
+    'qmgr -c set node node2.example.com properties \+= prop3',
+    'qmgr -c set node node2.example.com properties \+= prop4',
+    'qmgr -c delete node node0.example.com',
+], [
+    # protected attributes
+    'qmgr -c .*? node1.example.com.*(status|(total|dedicated)_(sockets|numa_nodes|cores|threads))',
+]), "expected configure commands");
+
+
+done_testing;

--- a/ncm-pbsserver/src/test/resources/simple.pan
+++ b/ncm-pbsserver/src/test/resources/simple.pan
@@ -1,0 +1,44 @@
+object template simple;
+
+# mock pkg_repl
+function pkg_repl = { null; };
+
+include 'components/pbsserver/config';
+
+# remove the dependencies
+'/software/components/pbsserver/dependencies' = null;
+
+"/software/components/pbsserver/pbsroot" = '/var/spool/pbs';
+
+"/software/components/pbsserver/server/manualconfig" = false;
+prefix "/software/components/pbsserver/server/attlist";
+"server_name" = "master.example.com";
+"down_on_error" = true;
+"scheduling" = true;
+
+"/software/components/pbsserver/queue/manualconfig" = false;
+prefix "/software/components/pbsserver/queue/queuelist/default";
+"attlist/enabled" = true;
+"attlist/queue_type" = "Route";
+"attlist/route_destinations" = '"short,long"';
+"attlist/started" = true;
+"manualconfig" = false;
+
+prefix "/software/components/pbsserver/queue/queuelist/q72h";
+"attlist/Priority" = 60;
+"attlist/acl_group_enable" = true;
+"attlist/acl_group_sloppy" = true;
+"attlist/acl_groups" = '"gpilot,wheel"';
+"attlist/enabled" = true;
+"attlist/queue_type" = "Execution";
+"manualconfig" = false;
+
+"/software/components/pbsserver/node/manualconfig" = false;
+prefix "/software/components/pbsserver/node/nodelist/node1.example.com";
+"attlist/np" = 20;
+"attlist/properties" = 'prop2,prop3';
+"manualconfig" = false;
+prefix "/software/components/pbsserver/node/nodelist/node2.example.com";
+"attlist/np" = 22;
+"attlist/properties" = 'prop3,prop4';
+"manualconfig" = false;


### PR DESCRIPTION
Also handle readonly note node attribute (new in torque6)