### PR TITLE
ncm-vomsclient: clean up documentation

### DIFF
--- a/ncm-vomsclient/src/main/pan/components/vomsclient/schema.pan
+++ b/ncm-vomsclient/src/main/pan/components/vomsclient/schema.pan
@@ -10,22 +10,41 @@ include 'quattor/schema';
 include 'pan/types';
 
 type structure_vomsclient_voms_info = {
+    @{The complete name of the VO, if the 'vos' key is an alias name. This
+    property is deprecated : it is recommended to use the complete name of the
+    VO as 'vos' key.}
     'name' ? string
+    @{The complete hostname of the VOMS server.}
     'host' : type_fqdn
+    @{The port number of the VOMS server.}
     'port' : type_port
+    @{The certificate for the server.}
     'cert' : string
+    @{The expiring certificate for the server. This allows smooth transition
+    between 2 certificates.}
     'oldcert' ? string
-        'DN' ? string
-        'issuer' ? string
+    @{DN of VOMS server certificate.}
+    'DN' ? string
+    @{DN of VOMS server certificate issuer.}
+    'issuer' ? string
 };
 
 type ${project.artifactId}_component = {
     include structure_component
+    @{Use LSC format instead of certificate to configure vomsCertsDir.}
     'lscfile' ? boolean
+    @{The directory to write the VOMS server certificates into. If the
+    directory doesn't exist, it is created. It will remove all managed
+    files and create new ones each time the configuration is done.}
     'vomsCertsDir' ? string
+    @{The directory to write the VOMS server parameters into. If the
+    directory doesn't exist, it is created. It will remove all managed
+    file and create new ones each time the configuration is done.}
     'vomsServersDir' ? string
+    @{This is a named list of VOMS VO information. Each key should be the
+    VO name. The value is a list of dict: each dict describes one VOMS server
+    supporting the VO.}
     'vos' ? structure_vomsclient_voms_info[]{}
 };
 
 bind '/software/components/vomsclient' = ${project.artifactId}_component;
-

--- a/ncm-vomsclient/src/main/perl/vomsclient.pod
+++ b/ncm-vomsclient/src/main/perl/vomsclient.pod
@@ -15,78 +15,16 @@ clients.  This writes the VOMS server certificates to the vomsCertsDir
 directory and the VOMS server parameters to the vomsServersDir
 directory. 
 
-=head1 RESOURCES
-
-=head2 /software/components/vomsclient/vomsCertsDir (/etc/grid-security/vomsdir)
-
-The directory to write the VOMS server certificates into.  If the
-directory doesn't exist, it is created.  It will remove all managed
-files and create new ones each time the configuration is done. 
-
-=head2 /software/components/vomsclient/vomsServersDir (/opt/edg/etc/vomses)
-
-The directory to write the VOMS server parameters into.  If the
-directory doesn't exist, it is created.  It will remove all managed
-file and create new ones each time the configuration is done. 
-
-=head2 /software/components/vomsclient/vos 
-
-This is a named list of VOMS VO information.  Each key should be the
-VO name. The value is a list of nlist : each nlist describes one VOMS server 
-supporting the VO. Supported properties for each VOMS server are described below.
-  
-
-=head2 VOMS server properties
-
-Each VOMS server is described with a nlist. The following properties 
-can be used to describe one VOMS server.
-
-=head3 name (optional, deprecated)
-
-The complete name of the VO, if the 'vos' key is an alias name. This
-property is deprecated : it is recommended to use the complete name of the 
-VO as 'vos' key. 
-
-=head3 host (required)
-
-The complete hostname of the VOMS server.
-
-=head3 port (required)
-
-The port number of the VOMS server.
-
-=head3 cert (required)
-
-The certificate for the server. 
-
-=head3 oldcert (optional)
-
-The expiring certificate for the server. This allows smooth transition
-between 2 certificates. 
-
-=head3 DN (optional)
-
-DN of VOMS server certificate
-
-=head3 issuer (optional)
-
-DN of VOMS server certificate issuer.
-
-=head3 lscfile (optional)
-
-Use LSC format instead of certificate to configure vomsCertsDir
-
 =head1 EXAMPLE
 
-"/software/components/vomsclient/vos" = npush("somevo.example.org", 
-  list(nlist(
-    "host","vo.somevo.example.org",
-    "port","20000",
-    "cert", <<EOF)));
-----BEGIN CERTIFICATE----
-... encoded binary info ...
-----END CERTIFICATE----
-EOF
-
+    "/software/components/vomsclient/vos" = npush("somevo.example.org",
+        list(dict(
+            "host", "vo.somevo.example.org",
+            "port", "20000",
+            "cert", <<EOF)));
+            ----BEGIN CERTIFICATE----
+            ... encoded binary info ...
+            ----END CERTIFICATE----
+        EOF
 
 =cut


### PR DESCRIPTION
 - move schema documentation to schema
 - replace nlist with dict
 - make sure example block is a code block