### PR TITLE
ncm-gsissh: documentation fix: make sure example is rendered as code …

### DIFF
--- a/ncm-gsissh/src/main/perl/gsissh.pod
+++ b/ncm-gsissh/src/main/perl/gsissh.pod
@@ -42,7 +42,7 @@ always configured even if there are no options.
 
     "/software/components/gsissh/server/port" = 1975;
     "/software/components/gsissh/server/options" =
-          nlist(
+          dict(
               "PermitRootLogin", "no",
               "RSAAuthentication", "no",
               "PubkeyAuthentication", "no",

--- a/ncm-gsissh/src/main/perl/gsissh.pod
+++ b/ncm-gsissh/src/main/perl/gsissh.pod
@@ -40,12 +40,13 @@ always configured even if there are no options.
 
 =head1 EXAMPLE
 
-"/software/components/gsissh/server/port" = 1975;
-"/software/components/gsissh/server/options" = 
-  nlist("PermitRootLogin", "no",
-        "RSAAuthentication", "no",
-        "PubkeyAuthentication", "no",
-        "PasswordAuthentication", "no",
-        "ChallengeResponseAuthentication", "no");
+    "/software/components/gsissh/server/port" = 1975;
+    "/software/components/gsissh/server/options" =
+          nlist(
+              "PermitRootLogin", "no",
+              "RSAAuthentication", "no",
+              "PubkeyAuthentication", "no",
+              "PasswordAuthentication", "no",
+              "ChallengeResponseAuthentication", "no");
 
 =cut


### PR DESCRIPTION
…block