### PR TITLE
ncm-pbsserver: add gpus and gpu_status to filter pbsnodes pattern

### DIFF
--- a/ncm-pbsserver/src/main/perl/pbsserver.pm
+++ b/ncm-pbsserver/src/main/perl/pbsserver.pm
@@ -17,6 +17,7 @@ Readonly::Array my @FILTER_PBSNODES_PATTERNS => qw(
     status jobs note
     mom_(manager|service)_port
     (total|dedicated)_(sockets|numa_nodes|cores|threads)
+    gpus gpu_status
 );
 
 


### PR DESCRIPTION
These attributes are set by the pbs_server and cannot be touched by this
component.