### PR TITLE
Override RPM URL to correct path

### DIFF
--- a/ncm-condorconfig/pom.xml
+++ b/ncm-condorconfig/pom.xml
@@ -103,6 +103,7 @@
                 </sources>
               </mapping>
             </mappings>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
           </configuration>
         </plugin>
       </plugins>

--- a/ncm-dcache/pom.xml
+++ b/ncm-dcache/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-dpmlfc/pom.xml
+++ b/ncm-dpmlfc/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-gacl/pom.xml
+++ b/ncm-gacl/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-gip2/pom.xml
+++ b/ncm-gip2/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-glitestartup/pom.xml
+++ b/ncm-glitestartup/pom.xml
@@ -101,6 +101,7 @@
                 </sources>
               </mapping>
             </mappings>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
           </configuration>
         </plugin>
       </plugins>

--- a/ncm-globuscfg/pom.xml
+++ b/ncm-globuscfg/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-gridmapdir/pom.xml
+++ b/ncm-gridmapdir/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-gsissh/pom.xml
+++ b/ncm-gsissh/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-lbconfig/pom.xml
+++ b/ncm-lbconfig/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-lcas/pom.xml
+++ b/ncm-lcas/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-lcgbdii/pom.xml
+++ b/ncm-lcgbdii/pom.xml
@@ -103,6 +103,7 @@
                 </sources>
               </mapping>
             </mappings>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
           </configuration>
         </plugin>
       </plugins>

--- a/ncm-lcgmonjob/pom.xml
+++ b/ncm-lcgmonjob/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-lcmaps/pom.xml
+++ b/ncm-lcmaps/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-maui/pom.xml
+++ b/ncm-maui/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-mkgridmap/pom.xml
+++ b/ncm-mkgridmap/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-myproxy/pom.xml
+++ b/ncm-myproxy/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-pbsclient/pom.xml
+++ b/ncm-pbsclient/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-pbsknownhosts/pom.xml
+++ b/ncm-pbsknownhosts/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-pbsserver/pom.xml
+++ b/ncm-pbsserver/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+    <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-vomsclient/pom.xml
+++ b/ncm-vomsclient/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/ncm-wlconfig/pom.xml
+++ b/ncm-wlconfig/pom.xml
@@ -103,6 +103,7 @@
                 </sources>
               </mapping>
             </mappings>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
           </configuration>
         </plugin>
       </plugins>

--- a/ncm-wmsclient/pom.xml
+++ b/ncm-wmsclient/pom.xml
@@ -103,6 +103,7 @@
                 </sources>
               </mapping>
             </mappings>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
           </configuration>
         </plugin>
       </plugins>

--- a/ncm-wmslb/pom.xml
+++ b/ncm-wmslb/pom.xml
@@ -96,6 +96,7 @@
                 </sources>
               </mapping>
             </mappings>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
           </configuration>
         </plugin>
       </plugins>

--- a/ncm-xrootd/pom.xml
+++ b/ncm-xrootd/pom.xml
@@ -47,5 +47,18 @@
     </contributor>
   </contributors>
 
-  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <configuration>
+            <url>https://github.com/quattor/configuration-modules-grid/tree/master/ncm-${project.artifactId}</url>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>


### PR DESCRIPTION
`maven-tools/build-profile` points this at `configuration-modules-core`.
This should eventually be resolved properly by merging the core and grid repositories.