### PR TITLE
Only search for the parent POM in Maven repositories

### DIFF
--- a/ncm-condorconfig/pom.xml
+++ b/ncm-condorconfig/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-dcache/pom.xml
+++ b/ncm-dcache/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-dpmlfc/pom.xml
+++ b/ncm-dpmlfc/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-gacl/pom.xml
+++ b/ncm-gacl/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-gip2/pom.xml
+++ b/ncm-gip2/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-glitestartup/pom.xml
+++ b/ncm-glitestartup/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-globuscfg/pom.xml
+++ b/ncm-globuscfg/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-gridmapdir/pom.xml
+++ b/ncm-gridmapdir/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-gsissh/pom.xml
+++ b/ncm-gsissh/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-lbconfig/pom.xml
+++ b/ncm-lbconfig/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-lcas/pom.xml
+++ b/ncm-lcas/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-lcgbdii/pom.xml
+++ b/ncm-lcgbdii/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-lcgmonjob/pom.xml
+++ b/ncm-lcgmonjob/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-lcmaps/pom.xml
+++ b/ncm-lcmaps/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-maui/pom.xml
+++ b/ncm-maui/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-mkgridmap/pom.xml
+++ b/ncm-mkgridmap/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-myproxy/pom.xml
+++ b/ncm-myproxy/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-pbsclient/pom.xml
+++ b/ncm-pbsclient/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-pbsknownhosts/pom.xml
+++ b/ncm-pbsknownhosts/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-pbsserver/pom.xml
+++ b/ncm-pbsserver/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-vomsclient/pom.xml
+++ b/ncm-vomsclient/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-wlconfig/pom.xml
+++ b/ncm-wlconfig/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-wmsclient/pom.xml
+++ b/ncm-wmsclient/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-wmslb/pom.xml
+++ b/ncm-wmslb/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>

--- a/ncm-xrootd/pom.xml
+++ b/ncm-xrootd/pom.xml
@@ -13,6 +13,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.62</version>
+    <relativePath />
   </parent>
 
   <licenses>


### PR DESCRIPTION
This gets rid of the messages like:

> Project build error: 'parent.relativePath' of POM org.quattor.cfg.module:foo:1.2.3-SNAPSHOT (/foo/bar/configuration-modules-core/ncm-foo/pom.xml) points at org.quattor:configuration-modules-core instead of org.quattor.maven:build-profile, please verify your project structure