### PR TITLE
small error with the creation of the lsc voms file from quat…

### DIFF
--- a/ncm-vomsclient/src/main/perl/vomsclient.pm
+++ b/ncm-vomsclient/src/main/perl/vomsclient.pm
@@ -349,7 +349,7 @@ sub getCertSubject () {
   
   # Extract the subject name using OpenSSL to help avoid
   # typos.
-  my $subject = `echo "$cert" | openssl x509 -noout -subject`;
+  my $subject = `echo "$cert" | openssl x509 -noout -subject -nameopt compat`;
   if ($?) {
     $self->error("cannot extract subject name for certificate");
     return(undef);
@@ -378,7 +378,7 @@ sub getIssuer () {
   return;
  }
 
- my $issuer = `echo "$cert" | openssl x509 -noout -issuer`;
+ my $issuer = `echo "$cert" | openssl x509 -noout -issuer -nameopt compat`;
  if ($?) {
   $self->error('cannot extract issuer name from certificate');
   return(undef);


### PR DESCRIPTION
Error in  openssl-1.1.1k-6.el8.x86_64, the default format of subject or issuer DN  with "commas" is not understood with xrootd voms lib and the extraction of voms attributes failed, when the component creates the lsc voms file 

  e.g --> https://stackoverflow.com/questions/56130510/openssl-issuer-subject-format-differences

  On the ncm component
  /usr/lib/perl/NCM/Component/vomsclient.pm

  cat  ./lib/perl/NCM/Component/vomsclient.pm |grep openssl
   my $subject = echo "$cert" | openssl x509 -noout -subject`;
   my $issuer = echo "$cert" | openssl x509 -noout -issuer`;

  I  add the compat -nameopt 
  So
  my $subject = echo "$cert" | openssl x509 -noout -subject -nameopt compat`;
  my $issuer = echo "$cert" | openssl x509 -noout -issuer -nameopt compat`;